### PR TITLE
Fix word display and restore default team names

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -33,16 +33,20 @@ function getRandomTeamName() {
 
 function getRandomWord() {
   const randomIndex = Math.floor(Math.random() * words.length)
-  const word = words.splice(randomIndex, 1)
+  const word = words.splice(randomIndex, 1)[0]
   return word
 }
 
 function onLaunch() {
   loadWords().then(() => {
-    setRandomNames()
-    if (localStorage.getItem('team1') != null || localStorage.getItem('team2') != null) {
+    const team1 = localStorage.getItem('team1')
+    const team2 = localStorage.getItem('team2')
+    if (team1 && team2) {
+      window.team1Name.value = team1
+      window.team2Name.value = team2
       window.continueBtn.style.display = 'block'
     } else {
+      setRandomNames()
       window.continueBtn.style.display = 'none'
     }
   })
@@ -68,7 +72,7 @@ function startGame() {
 }
 
 function newGame() {
-  localStorage.clear
+  localStorage.clear()
 
   if (window.team1Name.value && window.team2Name.value) {
     localStorage.setItem('team1', window.team1Name.value)


### PR DESCRIPTION
## Summary
- Ensure random words render correctly on the game screen
- Restore automatic team naming when no saved teams exist
- Clear local storage when starting a new game to prevent stale data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e43304c483268574743ade74ceff